### PR TITLE
* Added an option for stream content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 
+ - Support for stream-like data in `discljord.messaging/create-message!`
+
 ## [0.2.8] - 2020-04-13
 ### Added
  - Support for audit log reasons on all requests made with `discljord.messaging`

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -114,9 +114,13 @@
   Keyword Arguments:
   :user-agent changes the User-Agent header sent to Discord.
   :tts is a boolean, defaulting to false, which tells Discord to read
-       your message out loud."
+       your message out loud.
+  :file is a java.io.File object specifying a file for Discord to attach to the message.
+  :attachments is a collection of file-like objects to attach to the message.
+  :stream is a map that has a :content of a java.io.InputStream and a :filename of the filename to attach to the message.
+  :embed is a map specifying the embed format for the message (See Discord API)"
   []
-  [content tts nonce embed file allowed-mentions])
+  [content tts nonce embed file allowed-mentions attachments stream])
 
 (defn ^:deprecated send-message!
   [conn channel-id msg & {:keys [tts none embed file] :as opts}]


### PR DESCRIPTION
Added a 'stream' option to :create-message to allow objects that can be coerced into InputStream to be handed over to http to create attachments.   The specific use case is that I can use it to stream from S3 without a tempfile in the middle, but it should still work for any InputStream.

Usage is like:

:stream {:content (InputStream.) :filename "foo.png"}