### PR TITLE
CDN Namespace with utility functions for avatar, icon etc. urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+ - Namespace with utilities to create URLs to Discord's CDN, such as avatars or icons
  - Namespace with functions for validating if a user has a given permission
+ - Message formatting utilities including functions to create mentions, Markdown styling and user tags (User#1234)
  - Support for get current application information endpoint
  - Middleware to cache information that Discord sends during events
  - Function to create an event handler which dispatches to functions based on event type
@@ -13,7 +15,6 @@ Discljord follows semantic versioning.
  - Middleware for mapping and filtering
  - Middleware to concat handlers
  - Middleware for event handlers
- - Message formatting utilities including functions to create mentions, Markdown styling and user tags (User#1234)
 
 ### Changed
  - Gateway connections now use zlib transport compression

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -60,7 +60,7 @@
   [user]
   (or (user-avatar user) (default-user-avatar user)))
 
-(defn size
+(defn resize
   "Adds a size query parameter to the given image url, resulting in a resize of the image.
   Any power of 2 between 16 and 4096 is a valid size."
   [url size]

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -47,8 +47,8 @@
 
 (defn default-user-avatar
   "Takes a user object or a discriminator and returns a url to the default avatar image of that user/discriminator."
-  [user]
-  (str base-url "/embed/avatars/" (mod (cond-> user (map? user) :discriminator) 5) ".png"))
+  [user-or-discrim]
+  (str base-url "/embed/avatars/" (mod (cond-> user-or-discrim (map? user-or-discrim) :discriminator) 5) ".png"))
 
 (def user-avatar
   "Takes a user object and returns a url to the avatar of that user or `nil` if the user does not have an avatar."

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -6,6 +6,7 @@
 
 (defn custom-emoji
   "Takes a custom emoji object or id and returns a url to the image data.
+
   Note that an id alone is not enough to determine whether the emoji is animated or not,
   so if you pass an id you will always get a url to a png."
   [emoji]
@@ -56,17 +57,20 @@
 
 (defn effective-user-avatar
   "Takes a user object and returns a url to the effective avatar of that user.
+
   I.e., if the user has a custom avatar, it returns that, otherwise it returns the default avatar for that user."
   [user]
   (or (user-avatar user) (default-user-avatar user)))
 
 (def application-icon
   "Takes an OAuth2 application info object and returns a url to its icon.
+
   The current application info is obtainable via [[discljord.messaging/get-current-application-information!]]."
   (image-url-generator "app-icons" :icon))
 
 (defn resize
   "Adds a size query parameter to the given image url, resulting in a resize of the image.
+
   Any power of 2 between 16 and 4096 is a valid size."
   [url size]
   (str url "?size=" size))

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -60,6 +60,11 @@
   [user]
   (or (user-avatar user) (default-user-avatar user)))
 
+(def application-icon
+  "Takes an OAuth2 application info object and returns a url to its icon.
+  The current application info is obtainable via [[discljord.messaging/get-current-application-information!]]."
+  (image-url-generator "app-icons" :icon))
+
 (defn resize
   "Adds a size query parameter to the given image url, resulting in a resize of the image.
   Any power of 2 between 16 and 4096 is a valid size."

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -1,0 +1,67 @@
+(ns discljord.cdn
+  "Namespace with functions to create [cdn urls](https://discord.com/developers/docs/reference#image-formatting) to image data from API entities such as users or guilds."
+  (:require [clojure.string :refer [starts-with?]]))
+
+(def base-url "https://cdn.discordapp.com")
+
+(defn custom-emoji
+  "Takes a custom emoji object or id and returns a url to the image data.
+  Note that an id alone is not enough to determine whether the emoji is animated or not,
+  so if you pass an id you will always get a url to a png."
+  [emoji]
+  (str base-url "/emojis/"
+       (cond-> emoji (map? emoji) :id) \. (if (:animated emoji) "gif" "png")))
+
+(defn animated?
+  "Takes an image data hash and returns whether it represents an animated image (gif) or not."
+  [hash]
+  (starts-with? hash "a_"))
+
+(defn file-name
+  "Takes an image data hash and returns the file name it represents with the correct extension."
+  [hash]
+  (str hash \. (if (animated? hash) "gif" "png")))
+
+(defn image-url-generator
+  "Returns a function that, given an object with an id and an image data hash, returns a url to that image."
+  [path hash-key]
+  (fn [{:keys [id] hash hash-key}]
+    (when hash
+      (str base-url \/ path \/ id \/ (file-name hash)))))
+
+(def guild-icon
+  "Takes a guild and returns a url to the guild's icon or `nil` if the guild does not have an icon."
+  (image-url-generator "icons" :icon))
+
+(def guild-splash
+  "Takes a guild and returns a url to the guild's splash or `nil` if the guild does not have a splash."
+  (image-url-generator "splashes" :splash))
+
+(def guild-discovery-splash
+  "Takes a guild and returns a url to the guild's discovery splash or `nil` if the guild does not have a discovery splash."
+  (image-url-generator "discovery-splashes" :discovery-splash))
+
+(def guild-banner
+  "Takes a guild and returns a url to the guild's banner or `nil` if the guild does not have a banner."
+  (image-url-generator "banners" :banner))
+
+(defn default-user-avatar
+  "Takes a user object or a discriminator and returns a url to the default avatar image of that user/discriminator."
+  [user]
+  (str base-url "/embed/avatars/" (mod (cond-> user (map? user) :discriminator) 5) ".png"))
+
+(def user-avatar
+  "Takes a user object and returns a url to the avatar of that user or `nil` if the user does not have an avatar."
+  (image-url-generator "avatars" :avatar))
+
+(defn effective-user-avatar
+  "Takes a user object and returns a url to the effective avatar of that user.
+  I.e., if the user has a custom avatar, it returns that, otherwise it returns the default avatar for that user."
+  [user]
+  (or (user-avatar user) (default-user-avatar user)))
+
+(defn size
+  "Adds a size query parameter to the given image url, resulting in a resize of the image.
+  Any power of 2 between 16 and 4096 is a valid size."
+  [url size]
+  (str url "?size=" size))

--- a/src/discljord/formatting.clj
+++ b/src/discljord/formatting.clj
@@ -4,21 +4,25 @@
 
 (def user-mention
   "Regex pattern that matches user or member mentions.
+
   Captures the user id in its first capture group labelled \"id\"."
   #"<@!?(?<id>\d+)>")
 
 (def role-mention
   "Regex pattern that matches role mentions.
+
   Captures the role id in its first capture group labelled \"id\"."
   #"<@&(?<id>\d+)>")
 
 (def channel-mention
   "Regex pattern that matches text channel mentions.
+
   Captures the channel id in its first capture group labelled \"id\"."
   #"<#(?<id>\d+)>")
 
 (def emoji-mention
   "Regex pattern that matches custom emoji mentions.
+
   (Optionally) captures the `a` prefix in its first capture group labelled \"animated\"
   to indicate if the emoji is animated; Captures the emoji name in its second capture group labelled
   \"name\" and the id in a last capture group labelled \"id\"."
@@ -44,6 +48,7 @@
 
 (defn mention-emoji
   "Takes an emoji object or a custom emoji id and returns a mention of that emoji for use in messages.
+
   A provided emoji object may also represent a regular unicode emoji with just a name,
   in which case that name will be returned."
   [emoji]
@@ -66,6 +71,7 @@
 
 (defn code-block
   "Puts the given text in a codeblock with corresponding syntax highlighting, if a language is given.
+
   I.e.:
   ```lang
   text
@@ -95,6 +101,7 @@
 
 (defn block-quote
   "Returns the given text in a blockquote, with new lines pre- and appended.
+
   I.e.:
   > text"
   [text]
@@ -102,11 +109,13 @@
 
 (def full-block-quote
   "The full block quote (`>>>`).
+
   Everything that follows this separator is shown as a block quote in Discord messages."
   "\n>>> ")
 
 (defn embed-link
   "Creates an inline-style link with an optional title.
+
   I.e.: [text](url \"title\") or [text](url).
   Can only be used in embeds, not in regular messages."
   ([text url title] (str \[ text "](" url \space \" title \" \)))


### PR DESCRIPTION
This PR adds a new namespace with several functions to [get images from Discord's cdn](https://discord.com/developers/docs/reference#image-formatting), covering

- custom emoji
- guild icon
- guild splash
- guild discovery splash
- guild banner
- default user avatar
- user avatar
- application icon

All of these functions return `nil` if the corresponding image does not exist (if a guild does not have a banner, for example). 
Additionally, there is a function to get the effective avatar of a user (if avatar present avatar else default avatar) and a function to resize images by adding a `size` query parameter.
