### PR TITLE
Snowflake Information Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 Discljord follows semantic versioning.
 
 ## [Unreleased]
+### Added
+- Namespace with functions to extract information from Discord's snowflake ids
 
 ## [1.1.0] - 2020-07-12
 ### Added

--- a/src/discljord/snowflakes.clj
+++ b/src/discljord/snowflakes.clj
@@ -3,7 +3,7 @@
   (:require [clojure.edn :as edn]))
 
 (def ^:const discord-epoch
-  "The Discord epoch, or the number of milliseconds that had passed since January 1, 1970 on January 1, 2015."
+  "The Discord epoch - the number of milliseconds that had passed since January 1, 1970, on January 1, 2015."
   1420070400000)
 
 (defn- parse-if-str [input]
@@ -15,24 +15,55 @@
                         (throw (IllegalArgumentException. "Snowflake string must represent a valid number"))))
     :else (throw (IllegalArgumentException. "Snowflake must be string or number"))))
 
-(defn timestamp [snowflake]
+(defn timestamp
+  "Returns the UNIX timestamp (ms) for when this id was generated.
+
+  Takes either a string or a number representing the snowflake."
+  [snowflake]
   (+ (bit-shift-right (parse-if-str snowflake) 22) discord-epoch))
 
-(defn internal-worker-id [snowflake]
+(defn internal-worker-id
+  "Returns the internal id of the worker that generated this id.
+
+  Takes either a string or a number representing the snowflake."
+  [snowflake]
   (bit-shift-right (bit-and (parse-if-str snowflake) 0x3E0000) 17))
 
-(defn internal-process-id [snowflake]
+(defn internal-process-id
+  "Returns the internal id of the process this id was generated on.
+
+  Takes either a string or a number representing the snowflake."
+  [snowflake]
   (bit-shift-right (bit-and (parse-if-str snowflake) 0x1F000) 15))
 
-(defn increment [snowflake]
+(defn increment
+  "Returns the increment of this id, i.e. the number of ids that had been generated before on its process.
+
+  Takes either a string or a number representing the snowflake."
+  [snowflake]
   (bit-and (parse-if-str snowflake) 0xFFF))
 
-(defn parse-snowflake [snowflake]
+(defn parse-snowflake
+  "Extracts all information from the given id and returns it as a map.
+
+  The map has the following keys:
+  `:id` - The input snowflake as a number
+  `:timestamp` - See [[timestamp]]
+  `:internal-worker-id` - See [[internal-worker-id]]
+  `:internal-process-id` - See [[internal-process-id]]
+  `:increment` - See [[increment]]"
+  [snowflake]
   (let [snowflake (parse-if-str snowflake)]
-    {:timestamp           (timestamp snowflake)
+    {:id                  snowflake
+     :timestamp           (timestamp snowflake)
      :internal-worker-id  (internal-worker-id snowflake)
      :internal-process-id (internal-process-id snowflake)
      :increment           (increment snowflake)}))
 
-(defn timestamp->snowflake [timestamp]
+(defn timestamp->snowflake
+  "Takes a UNIX milliseconds timestamp (like from `(System/currentTimeMillis)`) and returns it as a Discord snowflake id.
+
+  This can be used for paginated endpoints where ids are used to represent bounds like
+  'before' and 'after' to get results before, after or between timestamps."
+  [timestamp]
   (bit-shift-left (- timestamp discord-epoch) 22))

--- a/src/discljord/snowflakes.clj
+++ b/src/discljord/snowflakes.clj
@@ -1,0 +1,38 @@
+(ns discljord.snowflakes
+  "Contains utility functions to parse, deconstruct and create [snowflake ids](https://discord.com/developers/docs/reference#snowflakes)."
+  (:require [clojure.edn :as edn]))
+
+(def ^:const discord-epoch
+  "The Discord epoch, or the number of milliseconds that had passed since January 1, 1970 on January 1, 2015."
+  1420070400000)
+
+(defn- parse-if-str [input]
+  (cond
+    (number? input) input
+    (string? input) (let [parsed (edn/read-string input)]
+                      (if (number? parsed)
+                        parsed
+                        (throw (IllegalArgumentException. "Snowflake string must represent a valid number"))))
+    :else (throw (IllegalArgumentException. "Snowflake must be string or number"))))
+
+(defn timestamp [snowflake]
+  (+ (bit-shift-right (parse-if-str snowflake) 22) discord-epoch))
+
+(defn internal-worker-id [snowflake]
+  (bit-shift-right (bit-and (parse-if-str snowflake) 0x3E0000) 17))
+
+(defn internal-process-id [snowflake]
+  (bit-shift-right (bit-and (parse-if-str snowflake) 0x1F000) 15))
+
+(defn increment [snowflake]
+  (bit-and (parse-if-str snowflake) 0xFFF))
+
+(defn parse-snowflake [snowflake]
+  (let [snowflake (parse-if-str snowflake)]
+    {:timestamp           (timestamp snowflake)
+     :internal-worker-id  (internal-worker-id snowflake)
+     :internal-process-id (internal-process-id snowflake)
+     :increment           (increment snowflake)}))
+
+(defn timestamp->snowflake [timestamp]
+  (bit-shift-left (- timestamp discord-epoch) 22))


### PR DESCRIPTION
Adds a namespace with the functions suggested in #46 .

There is a function to obtain every piece of information encoded in snowflake ids, including `timestamp`, `internal-worker-id`, `internal-process-id` and `increment`. There is also a function to extract all of that information and return it as a map.

All of those functions accept both numbers and strings representing numbers as arguments. Accepting numbers only would be inconvenient because Discord sends ids as strings for the most part, accepting strings only would possibly lead to redundant parsing. Also, sometimes Discord sends ids as numbers (when they stem from user input and are small enough).

Additionally, there is a function `timestamp->snowflake` that makes up an id based on the given timestamp. This is suggested in Discord's developer docs to query paginated endpoints based on timestamps.