### PR TITLE
Fix type issue in cdn/default-user-avatar

### DIFF
--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -1,6 +1,8 @@
 (ns discljord.cdn
   "Namespace with functions to create [cdn urls](https://discord.com/developers/docs/reference#image-formatting) to image data from API entities such as users or guilds."
-  (:require [clojure.string :refer [starts-with?]]))
+  (:require
+    [clojure.string :refer [starts-with?]]
+    [discljord.util :refer [parse-if-str]]))
 
 (def base-url "https://cdn.discordapp.com")
 
@@ -49,7 +51,7 @@
 (defn default-user-avatar
   "Takes a user object or a discriminator and returns a url to the default avatar image of that user/discriminator."
   [user-or-discrim]
-  (str base-url "/embed/avatars/" (mod (cond-> user-or-discrim (map? user-or-discrim) :discriminator) 5) ".png"))
+  (str base-url "/embed/avatars/" (mod (cond-> user-or-discrim (map? user-or-discrim) :discriminator true parse-if-str) 5) ".png"))
 
 (def user-avatar
   "Takes a user object and returns a url to the avatar of that user or `nil` if the user does not have an avatar."

--- a/src/discljord/snowflakes.clj
+++ b/src/discljord/snowflakes.clj
@@ -1,19 +1,10 @@
 (ns discljord.snowflakes
   "Contains utility functions to parse, deconstruct and create [snowflake ids](https://discord.com/developers/docs/reference#snowflakes)."
-  (:require [clojure.edn :as edn]))
+  (:require [discljord.util :refer [parse-if-str]]))
 
 (def ^:const discord-epoch
   "The Discord epoch - the number of milliseconds that had passed since January 1, 1970, on January 1, 2015."
   1420070400000)
-
-(defn- parse-if-str [input]
-  (cond
-    (number? input) input
-    (string? input) (let [parsed (edn/read-string input)]
-                      (if (number? parsed)
-                        parsed
-                        (throw (IllegalArgumentException. "Snowflake string must represent a valid number"))))
-    :else (throw (IllegalArgumentException. "Snowflake must be string or number"))))
 
 (defn timestamp
   "Returns the UNIX timestamp (ms) for when this id was generated.

--- a/src/discljord/util.clj
+++ b/src/discljord/util.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.data.json :as json]
    [clojure.spec.alpha :as s]
+   [clojure.edn :as edn]
    [clojure.string :as str]
    [discljord.specs :as ds]
    [clojure.tools.logging :as log]))
@@ -17,8 +18,8 @@
 (defn ^:deprecated set-logging-level!
   "Sets the logging level for discljord through tambre.
   Levels are :trace, :debug, :info, :warn, :error, :fatal, and :report"
-  [logging-level]
-  )
+  [logging-level])
+
 (s/fdef set-logging-level
   :args (s/cat :logging-level ::logging-level))
 
@@ -75,3 +76,12 @@
              :keyword keyword?
              :boolean boolean?
              :nil nil?))
+
+(defn parse-if-str [input]
+  (cond
+    (number? input) input
+    (string? input) (let [parsed (edn/read-string input)]
+                      (if (number? parsed)
+                        parsed
+                        (throw (IllegalArgumentException. "String must represent a valid number"))))
+    :else (throw (IllegalArgumentException. "Argument must be string or number"))))


### PR DESCRIPTION
I just noticed a bug in the code from #45 . It assumes that the user discriminator for the default avatar url is passed as a number, when in fact Discord provides it as a string. I therefore changed the function to coerce to number, parsing the string if necessary. For that purpose I reused a function from the snowflakes namespace, which I moved to the util namespace.