### PR TITLE
Add quick start to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,30 @@
 Discljord is a library for the easy creation of Discord Bots in Clojure! It works asyncronously by default, and has built-in support for sharding and rate-limits, with no extra work for the bot creator. Feel free to drop on by our [support server](https://discord.gg/284PgKZ) if you'd like to try it out or need any help.
 
 ## Version 1.0.0 Released
+
 With version 1.0.0 of discljord finally coming out, it's finally reaching "feature completion", in that it fits with my initial vision of what the library should provide. It has user-controlled sharding and transparent sharding, full support for the entire REST API, support for gateway communication, and transparent representations of all the events that discord sends.
 
 This does not however mean that the project is going into maintenance mode, but rather than further development will be to keep the project up to date with changes to Discord's API, and also add new features to make development of bots easier and more streamlined.
 
 Current future plans involve adding features for caching information Discord sends to the bot, validating user permissions, creating commands, etc.
+
+## Quick Start
+
+With [leiningen](https://leiningen.org) you can set up a project really quickly:
+
+1. Run `lein new discljord first-bot`
+
+2. Put your bot token in `config.edn`
+
+3. Run `lein run`
+
+4. Your bot should go online now!
+
+Alternatively, you can start a REPL (Read-Eval-Print-Loop) with `lein repl` and experiment with the API interactively.
+
+If you are new to Clojure, have a look at a [language introduction](https://gist.github.com/yogthos/be323be0361c589570a6da4ccc85f58f) before you dive straight in. You should also get a general idea of [how to use the REPL](https://clojure.org/guides/repl/introduction).
+
+The `start-bot!` and `stop-bot!` functions help you connect/disconnect to/from the Discord API from the REPL.
 
 ## Installation
 
@@ -26,13 +45,17 @@ If you use tools.deps, then add the following to your `:dependencies` key in you
 ## Usage
 
 To use discljord, add it to the project dependencies in leiningen's `project.clj` and run
+
 ```
 lein deps
 ```
+
 or to tools.deps' `deps.edn` and run
+
 ```
 clj -e "(println \"Dependencies downloaded\")"
 ```
+
 After that, discljord should be ready to go, and you can start building a bot!
 
 ### Bot Registration
@@ -251,21 +274,24 @@ The event pump provided by discljord will accept any function that takes an even
 This bot will send emoji to the channel that a reaction is added in, as well as perform the same hello-world response the previous bot did. The main difference is that the actual dispatch to different handler functions is done via data, rather than via a multimethod. Additionally, this adds the ability to call multiple handler functions with a single event.
 
 ### Intents
+
 As of right now, Discord will send your bot all events which happen on any guild that your bot is in, however you can specify [intents](https://discord.com/developers/docs/topics/gateway#gateway-intents) to specify which events you want to receive. In the future, Discord intends to make these intents mandatory. They can be specified as a keyword argument to `discljord.connections/connect-bot!`, and are represented as a set of keywords in lower-kebab-case.
 
 ## Logging
+
 Discljord uses [clojure.tools.logging](https://github.com/clojure/tools.logging) for all its logging, which means that you are responsible for providing it with a suitable logging implementation as well as configuration. If no configuration is provided, then it will likely default to whatever gets brought in by your other dependencies, potentially eventually falling back to `java.util.logging`, however it should still function even with no intervention by the library user.
 
 Logging levels in discljord follow a basic pattern that anything at a `warn` level or lower is handled by discljord, and `error` or `fatal` will be used to inform the user of something that they can or should take action in an attempt to fix. Besides the generalization, here is a more specific listing of the purpose of the logging levels:
 
- - Fatal :: Used when some condition is met that prevents discljord from continuing, even with user input
- - Error :: Used when an unhandled error occurs or when user error causes the application to fail
- - Warn :: Used when an error occurs but is handled by discljord without user input
- - Info :: Used for application-scale control flow
- - Debug :: Used for process-scale control flow
- - Trace :: Used for logging all communication events and function-level control flow
+- Fatal :: Used when some condition is met that prevents discljord from continuing, even with user input
+- Error :: Used when an unhandled error occurs or when user error causes the application to fail
+- Warn :: Used when an error occurs but is handled by discljord without user input
+- Info :: Used for application-scale control flow
+- Debug :: Used for process-scale control flow
+- Trace :: Used for logging all communication events and function-level control flow
 
 ## Known Issues
+
 None at the moment
 
 If you find any other issues, please report them, and I'll attempt to fix them as soon as possible!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Discljord](img/comp.png)
 
-Discljord is a library for the easy creation of Discord Bots in Clojure! It works asyncronously by default, and has built-in support for sharding and rate-limits, with no extra work for the bot creator. Feel free to drop on by our [support server](https://discord.gg/284PgKZ) if you'd like to try it out or need any help.
+Discljord is a library for the easy creation of Discord Bots in Clojure! It works asynchronously by default, and has built-in support for sharding and rate-limits, with no extra work for the bot creator. Feel free to drop on by our [support server](https://discord.gg/284PgKZ) if you'd like to try it out or need any help.
 
 ## Version 1.0.0 Released
 


### PR DESCRIPTION
Adds a quick start mentioning the new discljord leiningen template as well as a couple of links to learning resources to the readme. Also fixes a minor typo.