### PR TITLE
Add new permissions-int arity and permission-flags function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+ - `discljord.permissions/permission-flags` as a counterpart to `permission-int`
+ - `discljord.permissions/permission-int` arity to construct custom permission integers
  - Option to disable transport compression on the gateway api
  - Namespace with functions to extract information from Discord's snowflake ids
 

--- a/src/discljord/permissions.clj
+++ b/src/discljord/permissions.clj
@@ -41,11 +41,12 @@
   (map-invert permissions-bit))
 
 (defn permission-flags
-  "Returns a sequence of all permissions included in a given permission integer."
+  "Returns a set of all permissions included in a given permission integer."
   [perms-int]
   (->> (vals permissions-bit)
        (filter (comp (complement zero?) (partial bit-and perms-int)))
-       (map permissions-key)))
+       (map permissions-key)
+       (set)))
 
 (defn has-permission-flag?
   "Returns if the given permission integer includes a permission flag.

--- a/src/discljord/permissions.clj
+++ b/src/discljord/permissions.clj
@@ -44,13 +44,13 @@
   "Returns a sequence of all permissions included in a given permission integer."
   [perms-int]
   (->> (vals permissions-bit)
-       (filter (partial bit-and perms-int))
+       (filter (comp (complement zero?) (partial bit-and perms-int)))
        (map permissions-key)))
 
 (defn has-permission-flag?
   "Returns if the given permission integer includes a permission flag.
 
-  `perm` is a keyword from the keys of [[permissions-int]]."
+  `perm` is a keyword from the keys of [[permissions-bit]]."
   [perm perms-int]
   (when perms-int
     (when-let [bit (or (permissions-bit perm)
@@ -60,7 +60,7 @@
 (defn has-permission-flags?
   "Returns if the given permission integer includes all the given permission flags.
 
-  `perm` is a keyword from the keys of [[permissions-int]]."
+  `perm` is a keyword from the keys of [[permissions-bit]]."
   [perms perms-int]
   (every? #(has-permission-flag? % perms-int) perms))
 


### PR DESCRIPTION
This PR adds a new arity to `discljord.permissions/permissions-int` that allows for the construction of a permissions int based on a sequence of permission keywords. This is useful in situations where the API expects you to pass a custom permissions int, like when creating or modifying permission overwrites.

For the sake of completeness, I also added a counterpart to this function (`permission-flags`) that takes a permissions integer and returns a sequence of the included permission keys, such that:

```clj
(= (set perms) (set (-> perms permissions-int permission-flags)))
```

I also fixed two wrong references in the documentation