### PR TITLE
Slash Commands fixes and adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Discljord follows semantic versioning.
      - `get-guild-application-command-permissions!`
      - `get-application-command-permissions!`
      - `edit-application-command-permissions!`
+     - `batch-edit-application-command-permissions!`
    - Interactions Endpoints
      - `create-interaction-response!`
      - `get-original-interaction-response!`

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -68,11 +68,12 @@
                            prepend-major-var? (cons [(keyword major-var) major-var-type])
                            true vec)
         spec-keys (vec (map spec-for opts))
-        unqualified-params (cond->> (map (comp symbol name) params) prepend-major-var? (cons major-var))]
+        unqualified-params (cond->> (map (comp symbol name) params) prepend-major-var? (cons major-var))
+        unqualified-opts (mapv (comp keyword name) opts)]
     `(do
        (defn ~endpoint-name
          ~doc-str
-         [~'conn ~@unqualified-params ~'& {:keys ~opts :as ~'opts}]
+         [~'conn ~@unqualified-params ~'& {:keys ~unqualified-opts :as ~'opts}]
          (let [user-agent# (:user-agent ~'opts)
                audit-reason# (:audit-reason ~'opts)
                p# (util/derefable-promise-chan)

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -738,6 +738,14 @@
   [application-id guild-id command-id ms.command/permissions]
   [])
 
+(defendpoint batch-edit-application-command-permissions! nil
+  "Batch edits the permission settings for all commands in a guild.
+
+  This will overwrite all existing permissions for all commands in the guild.
+  Returns a promise containing the updated permission settings."
+  [application-id guild-id ms.command.guild/permissions-array]
+  [])
+
 ;; -------------------------------------------------
 ;; Interactions
 

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -721,7 +721,7 @@
   [application-id guild-id commands]
   [])
 
-(defendpoint get-guild-guild-application-command-permissions! nil
+(defendpoint get-guild-application-command-permissions! nil
   "Returns a promise containing the permission settings for all application commands accessible from the guild."
   [application-id guild-id]
   [])

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -835,6 +835,12 @@
   {:body (json/write-str {:permissions permissions})}
   (json-body body))
 
+(defdispatch :batch-edit-application-command-permissions
+  [_ application-id guild-id permissions] [] _ :put _ body
+  (str (guild-cmd-url application-id guild-id) "/permissions")
+  {:body (json/write-str permissions)}
+  (json-body body))
+
 (defmethod dispatch-http :create-interaction-response
   [token endpoint [prom interaction-id interaction-token type & {:as opts}]]
   (send-message! token (str "/interactions/" interaction-id \/ interaction-token "/callback") prom [] false (assoc opts :type type)))

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -238,7 +238,7 @@
 
 (s/def :command.option/type (set (vals command-option-types)))
 
-(s/def :command.option/name (string-spec #"[\w-]{1,32}"))
+(s/def :command.option/name (string-spec #"\S{1,32}"))
 (s/def :command.option/description (string-spec 1 100))
 (s/def :command.option/default boolean?)
 (s/def :command.option/required boolean?)
@@ -294,7 +294,7 @@
 
 (s/def :command.option/options :discljord.messaging.specs.command/options)
 
-(s/def :discljord.messaging.specs.command/name (string-spec #"[\w-]{1,32}"))
+(s/def :discljord.messaging.specs.command/name (string-spec #"\S{1,32}"))
 
 (s/def :discljord.messaging.specs.command/description (string-spec 1 100))
 

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -281,6 +281,15 @@
 
 (s/def :discljord.messaging.specs.command/permissions (s/coll-of :command/permission))
 
+(s/def :command/id ::command-id)
+
+(s/def :discljord.messaging.specs.command.guild/permissions
+  (s/keys :req-un [:command/id
+                   :discljord.messaging.specs.command/permissions]))
+
+(s/def :discljord.messaging.specs.command.guild/permissions-array
+  (s/coll-of :discljord.messaging.specs.command.guild/permissions))
+
 (s/def :discljord.messaging.specs.command/options
   (s/and (s/coll-of :command/option)
          (comp (partial >= 25) count)


### PR DESCRIPTION
This PR resolves a few issues that are currently still in develop:

- Adjust the command name & option specs to accept non-ascii characters
- Fix `get-guild-guild-application-command-permissions` => `get-guild-application-command-permissions`
- Fix: strip namespace from keyword options in endpoint functions
- Add new `batch-edit-application-command-permissions!` endpoint

I'd like to hear your opinion on the new spec names. The problem is, there are two "command permissions" objects in the Discord API:\
https://discord.com/developers/docs/interactions/slash-commands#guildapplicationcommandpermissions \
https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissions

In the `edit-application-command-permissions` endpoint, you need to pass an array of the former, in the batch endpoint you pass an array of the latter. If you could review my current naming for this, that'd be great.
