### PR TITLE
Implement message components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+ - Initial support for Message Components
  - New function for creating handlers for multiple events, `discljord.events/normalize-handlers`
  - Slash Commands Feature
    - Management Endpoints

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -144,7 +144,7 @@
   :stream is a map that has a :content of a java.io.InputStream and a :filename of the filename to attach to the message.
   :embed is a map specifying the embed format for the message (See Discord API)"
   []
-  [content tts nonce embed file allowed-mentions attachments stream message-reference])
+  [content tts nonce embed file allowed-mentions attachments stream message-reference components])
 
 (defn ^:deprecated send-message!
   [conn channel-id msg & {:keys [tts none embed file] :as opts}]

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -183,7 +183,7 @@
 (defendpoint edit-message! ::ds/channel-id
   "Edits the given message with the new content or embed. Returns a promise containing the new message."
   [message-id]
-  [content embed])
+  [content embed components])
 
 (defendpoint delete-message! ::ds/channel-id
   "Deletes the given message. Returns a promise containing a boolean of if it succeeded."
@@ -618,7 +618,7 @@
 (defendpoint execute-webhook! ::ds/webhook-id
   "Executes the given webhook. Returns a promise which contains either a boolean of if the message succeeded, or a map of the response body."
   [webhook-token]
-  [content file stream embeds wait username avatar-url tts allowed-mentions])
+  [content file stream embeds wait username avatar-url tts allowed-mentions components])
 
 (defendpoint get-webhook-message! ::ds/webhook-id
   "Returns the webhook message sent by the given webhook with the given id."
@@ -630,7 +630,7 @@
 
   Returns a promise containing the updated message object."
   [webhook-token message-id]
-  [content embeds allowed-mentions])
+  [content embeds allowed-mentions components])
 
 (defendpoint delete-webhook-message! ::ds/webhook-id
   "Deletes a messages that was sent from the given webhook.
@@ -766,7 +766,7 @@
 
   Returns a promise containing the updated message object"
   [application-id interaction-token]
-  [content embeds allowed-mentions])
+  [content embeds allowed-mentions components])
 
 (defendpoint delete-original-interaction-response! nil
   "Deletes the initial response to the given interaction.
@@ -780,14 +780,14 @@
 
   Returns a promise containing the message that was created."
   [application-id interaction-token]
-  [content file stream embeds username avatar-url tts allowed-mentions])
+  [content file stream embeds username avatar-url tts allowed-mentions components])
 
 (defendpoint edit-followup-message! ::ms/interaction-token
   "Edits a followup message to an interaction by its id.
 
   Returns a promise containing the updated message object."
   [application-id interaction-token message-id]
-  [content embeds allowed-mentions])
+  [content embeds allowed-mentions components])
 
 (defendpoint delete-followup-message! ::ms/interation-token
   "Deletes a followup message to an interaction by its id.

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -150,14 +150,14 @@
 
 (s/def :component/emoji
   (s/keys :req-un [:component.emoji/id :component.emoji/animated :component.emoji/name]))
-(s/def :component/custom-id (string-spec 0 100))
+(s/def :component/custom_id (string-spec 0 100))
 (s/def :component/url string?)
 (s/def :component/disabled boolean?)
 
 (s/def ::component
   (s/keys :req-un [:component/type]
           :opt-un [:component/style :component/label :component/emoji
-                   :component/custom-id :component/url :component/disabled ::components]))
+                   :component/custom_id :component/url :component/disabled ::components]))
 
 (s/def ::components
   (s/coll-of ::component))

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -377,6 +377,7 @@
           :opt-un [::embeds
                    ::tts
                    ::allowed-mentions
+                   ::components
                    :interaction-response.data/flags]))
 
 (s/def :widget/enabled boolean?)

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -130,6 +130,38 @@
 
 (s/def ::content ::message)
 
+(def component-types {:action-row 1, :button 2})
+
+(s/def :component/type (set (vals component-types)))
+
+(def component-styles
+  {:primary 1
+   :secondary 2
+   :success 3
+   :danger 4
+   :link 5})
+
+(s/def :component/style (set (vals component-styles)))
+(s/def :component/label (string-spec 0 80))
+
+(s/def :component.emoji/name string?)
+(s/def :component.emoji/id ::ds/snowflake)
+(s/def :component.emoji/animated boolean?)
+
+(s/def :component/emoji
+  (s/keys :req-un [:component.emoji/id :component.emoji/animated :component.emoji/name]))
+(s/def :component/custom-id (string-spec 0 100))
+(s/def :component/url string?)
+(s/def :component/disabled boolean?)
+
+(s/def ::component
+  (s/keys :req-un [:component/type]
+          :opt-un [:component/style :component/label :component/emoji
+                   :component/custom-id :component/url :component/disabled ::components]))
+
+(s/def ::components
+  (s/coll-of ::component))
+
 (s/def ::messages (s/coll-of ::message-id))
 
 (s/def ::overwrite-id ::ds/snowflake)


### PR DESCRIPTION
This PR implements [message components](https://discord.com/developers/docs/interactions/message-components). This actually requires barely any change, so it should be ready for review already.

Specifically, this adds specs for the new component objects and an additional optional parameter to the `create-message` endpoint.

The only thing left for me to check is whether components also work in webhook messages and/or interaction responses and add the parameter in those places too, if applicable.