### PR TITLE
Add timestamp formatting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+ - Timestamp formatting utilities in `discljord.formatting`
  - Additional arities on caching middleware functions for custom caching configuration and handlers
  - Threads Feature
    - Endpoints

--- a/src/discljord/formatting.clj
+++ b/src/discljord/formatting.clj
@@ -120,3 +120,23 @@
   Can only be used in embeds, not in regular messages."
   ([text url title] (str \[ text "](" url \space \" title \" \)))
   ([text url] (str \[ text "](" url \))))
+
+(def timestamp-styles
+  "The available timestamp display styles."
+  {:short-time \t
+   :long-time \T
+   :short-date \d
+   :long-date \D
+   :short-date-time \f
+   :long-date-time \F
+   :relative-time \R})
+
+(defn timestamp
+  "Creates a timestamp that will be displayed according to each user's locale.
+
+  An optional style (one of [[timestamp-styles]]) can be set. The default is `:short-date-time`.
+  The timestamp is a UNIX timestamp (seconds)."
+  ([unix-timestamp]
+   (str "<t:" unix-timestamp \>))
+  ([unix-timestamp style]
+   (str "<t:" unix-timestamp \: (timestamp-styles style) \>)))


### PR DESCRIPTION
This PR adds the `discljord.formatting/timestamp` function which helps with Discord markdown formatting for timestamps. E.g. `(fmt/timestamp 1633449730 :long-date-time)` => `"<t:1633449730:F>"`